### PR TITLE
comments/experiments about Lab03

### DIFF
--- a/Lab03/students-proposal/220930/geometry.py
+++ b/Lab03/students-proposal/220930/geometry.py
@@ -1,0 +1,74 @@
+"""
+geometry.smt
+sat
+(model
+  (define-fun xa () Real (to_real 1))
+  (define-fun ya () Real (to_real 3))
+  (define-fun xb () Real (to_real 2))
+  (define-fun yb () Real (to_real 7))
+  (define-fun x () Real (/ 1 4))
+  (define-fun m () Real (to_real 4))
+  (define-fun q () Real (to_real (- 1)))
+)
+
+geometry.py
+q := -1.0
+x := 1/4
+m := 4.0
+Xa := 1.0
+Ya := 3.0
+Xb := 2.0
+Yb := 7.0
+"""
+
+from pysmt.shortcuts import *
+from pysmt.solvers.msat import MathSAT5Solver
+
+xa = Symbol("Xa", REAL)
+ya = Symbol("Ya", REAL)
+xb = Symbol("Xb", REAL)
+yb = Symbol("Yb", REAL)
+
+x = Symbol("x", REAL)
+m = Symbol("m", REAL)
+q = Symbol("q", REAL)
+
+f = Symbol("f", FunctionType(REAL, (REAL,)))
+
+with Solver() as msat:
+    msat: MathSAT5Solver
+
+    # This produces the following exception:
+    # pysmt.exceptions.NonLinearError: (m * (Xb - Xa))
+    # To bypass the exception, edit the "walk_times" function in pysmt/solvers as follows:
+    # def walk_times(self, formula, args, **kwargs):
+    #     res = args[0]
+    #     nl_count = 0 if mathsat.msat_term_is_number(self.msat_env(), res) else 1
+    #     for x in args[1:]:
+    #         res = mathsat.msat_make_times(self.msat_env(), res, x)
+    #     return res
+    msat.add_assertion(Equals(f(x), Plus(Times(m, x), q)))
+
+    msat.add_assertion(Equals(xa, Real(1)))
+    msat.add_assertion(Equals(ya, Real(3)))
+    msat.add_assertion(Equals(xb, Real(2)))
+    msat.add_assertion(Equals(yb, Real(7)))
+
+    # This produces the following exception:
+    # pysmt.exceptions.ConvertExpressionError: Could not convert the input expression.
+    # The formula contains unsupported operators. The error was: Unsupported operator 'DIV' (node_type: 62)
+    # msat.add_assertion(Equals(m, Div((Minus(yb, ya)), Minus(xb, xa))))
+    # This works:
+    # msat.add_assertion(Equals(Times(m, Minus(xb, xa)), Minus(yb, ya)))
+    msat.add_assertion(Equals(m * (xb - xa), yb - ya))
+
+    # msat.add_assertion(Equals(q, Minus(yb, Times(m, xb))))
+    msat.add_assertion(Equals(q, yb - m * xb))
+
+    # msat.add_assertion(Equals(Function(f, [x]), Real(0)))
+    msat.add_assertion(Equals(f(x), Real(0)))
+
+    if msat.solve():
+        print(msat.get_model())
+    else:
+        print("UNSAT")

--- a/Lab03/students-proposal/220930/guesscode.py
+++ b/Lab03/students-proposal/220930/guesscode.py
@@ -1,0 +1,51 @@
+"""
+guesscode.smt
+sat
+(model
+  (define-fun e () Int 8)
+  (define-fun a () Int 2)
+  (define-fun b () Int 3)
+  (define-fun c () Int 6)
+  (define-fun d () Int 8)
+)
+
+guesscode.py
+C := 6
+A := 2
+D := 8
+B := 3
+"""
+
+from pysmt.shortcuts import *
+from pysmt.solvers.msat import MathSAT5Solver
+
+a = Symbol("A", INT)
+b = Symbol("B", INT)
+c = Symbol("C", INT)
+d = Symbol("D", INT)
+
+# with Solver(logic="NIA") as msat:
+with Solver() as msat:
+    msat: MathSAT5Solver
+
+    msat.add_assertion(Equals(d, Plus(a, c)))
+    msat.add_assertion(Equals(c, Times(a, b)))
+    msat.add_assertion(Equals(b, Minus(c, b)))
+    msat.add_assertion(Equals(d, Times(a, Int(4))))
+
+    msat.add_assertion(GE(a, Int(0)))
+    msat.add_assertion(LE(a, Int(9)))
+    msat.add_assertion(GE(b, Int(0)))
+    msat.add_assertion(LE(b, Int(9)))
+    msat.add_assertion(GE(c, Int(0)))
+    msat.add_assertion(LE(c, Int(9)))
+    msat.add_assertion(GE(d, Int(0)))
+    msat.add_assertion(LE(d, Int(9)))
+
+    msat.add_assertion(AllDifferent(a, b, c, d))
+
+    if msat.solve():
+        model = msat.get_model()
+        print(f"{model.get_value(a)}{model.get_value(b)}{model.get_value(c)}{model.get_value(d)}")
+    else:
+        print("UNSAT")

--- a/Lab03/students-proposal/220930/math_olimpics.py
+++ b/Lab03/students-proposal/220930/math_olimpics.py
@@ -1,0 +1,51 @@
+import time
+
+from pysmt.shortcuts import *
+from pysmt.solvers.msat import MathSAT5Solver
+
+a = Symbol("A", INT)
+b = Symbol("B", INT)
+c = Symbol("C", INT)
+
+h = Symbol("h", INT)
+k = Symbol("k", INT)
+
+with Solver() as msat:
+    msat: MathSAT5Solver
+
+    # msat.add_assertion(GT(a, Int(0)))
+    msat.add_assertion((a > 0) & (a <= 9))
+
+    # msat.add_assertion(GE(b, Int(0)))
+    msat.add_assertion((b >= 0) & (b <= 9))
+
+    # msat.add_assertion(GT(c, Int(0)))
+    msat.add_assertion((c > 0) & (c <= 9))
+
+    # abc = Plus(Times(Int(100), a), Times(Int(10), b), c)
+    abc = 100 * a + 10 * b + c
+    msat.add_assertion(Equals(Times(h, Int(4)), abc))
+
+    # cba = Plus(Times(Int(100), c), Times(Int(10), b), a)
+    cba = 100 * c + 10 * b + a
+    msat.add_assertion(Equals(Times(k, Int(4)), cba))
+
+    start_time = time.time()
+
+    n_models = 0
+    while msat.solve():
+        n_models += 1
+        print(f"model {n_models}: {msat.get_value(a)}{msat.get_value(b)}{msat.get_value(c)}")
+
+        # Slowest to fastest
+        # partial_model = [Equals(key, value) for key, value in msat.get_model()]
+        # partial_model = [Equals(key, msat.get_value(key)) for key in [a, b, c, h, k]]
+        partial_model = [Equals(key, msat.get_value(key)) for key in [a, b, c]]
+
+        # Both are slow
+        # partial_model = [Equals(key, msat.get_value(key)) for key in [h, k]]
+        # partial_model = [Equals(key, msat.get_value(key)) for key in [abc, cba]]
+
+        msat.add_assertion(Not(And(partial_model)))
+
+    print(f"elapsed time: {time.time() - start_time}")

--- a/Lab03/students-proposal/220930/pinphone.py
+++ b/Lab03/students-proposal/220930/pinphone.py
@@ -1,0 +1,72 @@
+from pysmt.shortcuts import *
+from pysmt.solvers.msat import MathSAT5Solver, MSatConverter
+
+x11 = Symbol("x11")
+x12 = Symbol("x12")
+x13 = Symbol("x13")
+x14 = Symbol("x14")
+x21 = Symbol("x21")
+x22 = Symbol("x22")
+x23 = Symbol("x23")
+x24 = Symbol("x24")
+x31 = Symbol("x31")
+x32 = Symbol("x32")
+x33 = Symbol("x33")
+x34 = Symbol("x34")
+x41 = Symbol("x41")
+x42 = Symbol("x42")
+x43 = Symbol("x43")
+x44 = Symbol("x44")
+
+var = [x11, x12, x13, x14,
+       x21, x22, x23, x24,
+       x31, x32, x33, x34,
+       x41, x42, x43, x44]
+
+with Solver() as msat:
+    msat: MathSAT5Solver
+
+    # For each step, only one pin can be used
+
+    msat.add_assertion(ExactlyOne(x11, x21, x31, x41))
+    msat.add_assertion(ExactlyOne(x12, x22, x32, x42))
+    msat.add_assertion(ExactlyOne(x13, x23, x33, x43))
+    msat.add_assertion(ExactlyOne(x14, x24, x34, x44))
+
+    # Each pin can be used once
+
+    msat.add_assertion(ExactlyOne(x11, x12, x13, x14))
+    msat.add_assertion(ExactlyOne(x21, x22, x23, x24))
+    msat.add_assertion(ExactlyOne(x31, x32, x33, x34))
+    msat.add_assertion(ExactlyOne(x41, x42, x43, x44))
+
+    # I've written the representation of patterns considering the possible choices instead of aborting unvalid choices;
+    # you can write the dual encoding and test their equivalence.
+
+    msat.add_assertion(Implies(x11, Or(x22, x32)))
+    msat.add_assertion(Implies(x21, Or(x12, x42)))
+    msat.add_assertion(Implies(x31, Or(x12, x42)))
+    msat.add_assertion(Implies(x41, Or(x22, x32)))
+
+    msat.add_assertion(Implies(x12, Or(x23, x33)))
+    msat.add_assertion(Implies(x22, Or(x13, x43)))
+    msat.add_assertion(Implies(x32, Or(x13, x43)))
+    msat.add_assertion(Implies(x42, Or(x23, x33)))
+
+    msat.add_assertion(Implies(x13, Or(x24, x34)))
+    msat.add_assertion(Implies(x23, Or(x14, x44)))
+    msat.add_assertion(Implies(x33, Or(x14, x44)))
+    msat.add_assertion(Implies(x43, Or(x24, x34)))
+
+    n_models = 0
+
+
+    def callback(model, converter: MSatConverter):
+        global n_models
+        n_models += 1
+        py_model = [converter.back(v) for v in model]
+        print(f"Model {n_models}: {py_model}")
+        return 1
+
+
+    msat.all_sat(var, lambda model: callback(model, msat.converter))


### PR DESCRIPTION
As suggested by the instructor for the sake of exercise, I re-implemented the exercises of Lab 03 in PySMT.
I made the following unfortunate findings; I hope they will be useful for others:

- `Div` does not work (at least using the MathSAT solver). In facts, I cannot see it [there](https://github.com/pysmt/pysmt/blob/master/pysmt/solvers/msat.py).
- There is no way of doing the modulo operation to obtain the remainder of a division. The work of [this 2018 pull request](https://github.com/pysmt/pysmt/pull/476) does not seem to be moving forward.
- Sometimes (see `geometry.py`), PySMT raises the following exception: `pysmt.exceptions.NonLinearError`. This is because, at the moment, PySMT does not yet support MathSAT's Non-Linear Integer Arithmetic (NIA) capabilities; see PySMT's [Solvers Support](https://github.com/pysmt/pysmt#solvers-support). To overcome this annoyance, a friend of mine (@masinag) suggests to apply the following quick-fix:
Rewrite the [`walk_times`](https://github.com/pysmt/pysmt/blob/master/pysmt/solvers/msat.py#L975) function as follows:
```
    def walk_times(self, formula, args, **kwargs):
        res = args[0]
        nl_count = 0 if mathsat.msat_term_is_number(self.msat_env(), res) else 1
        for x in args[1:]:
            if not mathsat.msat_term_is_number(self.msat_env(), x):
                nl_count += 1
            # if nl_count >= 2:
            #     raise NonLinearError(formula)
            # else:
            #     res = mathsat.msat_make_times(self.msat_env(), res, x)
            res = mathsat.msat_make_times(self.msat_env(), res, x)
        return res
```