### PR TITLE
Lab09's "Block" example: Impose that the first block to move is A

### DIFF
--- a/Lab09/blocks.smv
+++ b/Lab09/blocks.smv
@@ -30,6 +30,8 @@ VAR
   block_b : block(b, a, c);
   block_c : block(c, b, none);
 
+INIT move = move_a
+
 TRANS -- if a block moves, then it will still be clear and its location will
       -- change
   (move = move_a -> next(block_a.clear) &


### PR DESCRIPTION
As I show below, it is currently possible to select bad initial states to start the simulation with.
The initialization in the commit was present [in the last year repository's example](https://github.com/giuspek/past/blob/main/lab9/blocks.smv#L33); I simply restored it.

```
--    +---+        +---+
--    | A |        | C |
--    +---+        +---+
--    | B |  --->  | B |
--    +---+        +---+
--    | C |        | A |
-- ___|___|________|___|___
-- :::::::::: T :::::::::::
```

```
nuXmv > read_model -i Lab09/blocks.smv 
nuXmv > go
nuXmv > pick_state -i

***************  AVAILABLE STATES  *************
  
  ================= State =================
  0) -------------------------
  move = move_c
  block_a.clear = TRUE
  block_a.above = none
  block_a.below = b
  block_b.clear = FALSE
  block_b.above = a
  block_b.below = c
  block_c.clear = FALSE
  block_c.above = b
  block_c.below = none
  
  
  ================= State =================
  1) -------------------------
  move = move_a
  
  
  ================= State =================
  2) -------------------------
  move = move_b
  

Choose a state from the above (0-2): 
```