### PR TITLE
Lab09's "Hanoi" example: Impose that the first disk to move is d1

### DIFF
--- a/Lab09/hanoi.smv
+++ b/Lab09/hanoi.smv
@@ -1,6 +1,6 @@
 -- Hanoi problem with three poles (left, middle, right)
 -- and four ordered disks d1, d2, d3, d4,
--- disk d1 is the biggest one
+-- disk d1 is the smallest one
 
 MODULE main
 VAR
@@ -29,12 +29,14 @@ DEFINE
 	d4!=d2 &
 	d4!=d3;
 
--- initially all items are on the left pole
+-- initially all items are on the left pole;
+-- the smaller disk makes the first move
 INIT
   d1 = left &
   d2 = left &
   d3 = left &
-  d4 = left;
+  d4 = left & 
+  move_d1;
     
 TRANS
 	(next(clear_d3) = FALSE) -> (next(move) != 3)


### PR DESCRIPTION
Similar issue to PR #13

As I show below, it is currently possible to select bad initial states to start the simulation with.
The initialization in the commit was present [in the last year repository's example](https://github.com/giuspek/past/blob/main/lab9/hanoi.smv#L38); I simply restored it.

```
nuXmv > pick_state -i

***************  AVAILABLE STATES  *************
  
  ================= State =================
  0) -------------------------
  clear_d4 = FALSE
  clear_d3 = FALSE
  clear_d2 = FALSE
  clear_d1 = TRUE
  move_d4 = TRUE
  move_d3 = FALSE
  move_d2 = FALSE
  move_d1 = FALSE
  d1 = left
  d2 = left
  d3 = left
  d4 = left
  move = 4
  
  
  ================= State =================
  1) -------------------------
  move_d4 = FALSE
  move_d3 = TRUE
  move = 3
  
  
  ================= State =================
  2) -------------------------
  move_d3 = FALSE
  move_d2 = TRUE
  move = 2
  
  
  ================= State =================
  3) -------------------------
  move_d2 = FALSE
  move_d1 = TRUE
  move = 1
  

Choose a state from the above (0-3): 
```